### PR TITLE
feat(works): 画像読み込み中はblur画像を表示させる#38

### DIFF
--- a/app/_components/Article/index.tsx
+++ b/app/_components/Article/index.tsx
@@ -24,6 +24,9 @@ export default function Article({ data }: Props) {
           width={data.thumbnail?.width}
           height={data.thumbnail?.height}
           className="aspect-[1/0.7] rounded-xl object-cover shadow-outerXs"
+          loading="eager"
+          placeholder="blur"
+          blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP09/FvAgADSgFu6dMdIgAAAABJRU5ErkJggg=="
         />
       )}
 

--- a/app/_components/WorksListItem/index.tsx
+++ b/app/_components/WorksListItem/index.tsx
@@ -19,6 +19,8 @@ export default function WorksListItem({ works }: Props) {
             className="aspect-[1/0.8] h-[60%] min-w-[296px] rounded-lg object-cover shadow-outerXs group-hover:shadow-outerSm"
             sizes="(min-width: 640px) 296px, 100vw"
             loading="eager"
+            placeholder="blur"
+            blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP09/FvAgADSgFu6dMdIgAAAABJRU5ErkJggg=="
           />
         ) : (
           <Image src="" alt="No Image" width={800} height={800} />


### PR DESCRIPTION
Next.jsのblutDataURLを使って画像の読み込み中はぼかし画像を表示させる

feat #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved image loading experience with the addition of placeholders and blur effects.

- **Performance Improvements**
  - Enhanced visual performance during image loading with new `loading` attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->